### PR TITLE
deps: bump Java from 11 to 17

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           distribution: temurin
-          java-version: 11
+          java-version: 17
 
       - name: "Run tests"
         run: ./gradlew test --console=plain

--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -76,7 +76,7 @@ tasks.withType<Test> {
 // Apply a specific Java toolchain to ease working on different environments.
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(11))
+        languageVersion.set(JavaLanguageVersion.of(17))
     }
 }
 


### PR DESCRIPTION
We want to migrate the lib to KMP. Exposed is currently used for database implementation and is not supported in KMP, it's JVM only. A very solid choice for a SQLite database implementation with KMP support is SqlDelight. SqlDelight requires JDK 17 to be able to run the SqlDelight plugin and compiler, hence this change.
